### PR TITLE
remove SystemRequirements: C++11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,3 @@ URL: https://github.com/DavisVaughan/vsexample
 BugReports: https://github.com/DavisVaughan/vsexample/issues
 LinkingTo: 
     cpp11
-SystemRequirements: C++11


### PR DESCRIPTION
Same as https://github.com/renkun-ken/vscode-rcpp-demo/issues/5 and  https://github.com/renkun-ken/vscode-rcpp-demo/pull/6
i.e. compile flags from the `~/.R/Makevars`

```
CXXFLAGS= -g -O0
PKG_CXXFLAGS= -g -O0
```

are not used properly so vscode/gdb-setup may run into problems optimizing out relevant symbols for debugging.

I still have no idea what is happening internally; just took me ages to trace back to exactly this line, maybe you have @DavisVaughan ?

Here are the screenshots for your repo since renkuns `vscode-rcpp-demo` is a bit different:

1. With `SystemRequirements: C++11` (rightmost `-O` flag wins, so default R values are taken instead of what is specified in above `Makevars`)
<img src="https://user-images.githubusercontent.com/36898027/173104847-03c0a3d8-26dc-4bfd-b317-c2f9a0586011.png" width="50%" height="50%">


2. Removing `SystemRequirements: C++11` seems to fix it
<img src=https://user-images.githubusercontent.com/36898027/173104448-4dc27d7d-c21e-4133-bd06-7464dc288650.png width="50%" height="50%">

Platform:

```
r$> Sys.info()                                                                                                                                                                          
                                       sysname                                        release                                        version 
                                       "Linux"                            "5.4.0-113-generic" "#127-Ubuntu SMP Wed May 18 14:30:56 UTC 2022" 
                                      nodename                                        machine                                          login 
                                      "CGS-21"                                       "x86_64"                                      "unknown" 
                                          user                                 effective_user 
                                          "iz"                                           "iz" 

```